### PR TITLE
Chrome idle reset

### DIFF
--- a/roles/catalog/files/check-chrome.sh
+++ b/roles/catalog/files/check-chrome.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
-if ! [ -h /tmp/chrome/SingletonLock ]; then
-    export DISPLAY=:0.0 && /usr/bin/launch-chrome
+export DISPLAY=:0.0
+# If chrome isn't running, launch it
+if ! [ -h /tmp/chrome/SingletonLock ]; 
+then
+    /usr/bin/launch-chrome
+elif test `find "/tmp/chrome/SingletonLock" -mmin +7`
+	then
+# If chrome has been running for more than 7 minutes
+# and has been idle between 5-6.5 minutes then reset it
+		idle=$(xprintidle)
+		if [ $idle -ge 300000 ] && [ $idle -le 360000 ]
+		then
+			killall chrome
+			rm -r /tmp/chrome
+			/usr/bin/launch-chrome
+		fi
 fi

--- a/roles/catalog/tasks/main.yml
+++ b/roles/catalog/tasks/main.yml
@@ -77,3 +77,7 @@
 - name: cron to relaunch chrome if not open
   cron: name="check chrome" minute="*" job="/usr/bin/check-chrome > /dev/null 2>&1 &"
   become: false
+
+# Install xprintidle for idle reset script
+- name: install xprintidle
+  apt: name=xprintidle state=installed


### PR DESCRIPTION
Should complete #4 . xprintidle can be less than accurate so if chrome was used really briefly after being closed and reopened then it can miss it for relaunch but this is probably the safest.

Available for testing and merging.
